### PR TITLE
fix: исправлена ошибка #48

### DIFF
--- a/src/server/routes/yandexApi.ts
+++ b/src/server/routes/yandexApi.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { createProxyMiddleware } from 'http-proxy-middleware';
+import { createProxyMiddleware, fixRequestBody } from 'http-proxy-middleware';
 
 import { createDebug } from '@/server/utils';
 import { env } from '@/server/config';
@@ -34,6 +34,7 @@ router.use(
     }),
     logLevel: env.isDev() ? 'debug' : 'info',
     cookieDomainRewrite: '',
+    onProxyReq: fixRequestBody,
   })
 );
 


### PR DESCRIPTION
При добавлении мидлварей express.json и express.urlencoded express начинает парсить тело запроса, добавлены они были до подключения proxy поэтому запросы не проходили. Как обойти написано в офф. доке http-proxy-middleware