### PR TITLE
fix: исправлен деплой на heroku

### DIFF
--- a/src/database/config/index.ts
+++ b/src/database/config/index.ts
@@ -6,5 +6,5 @@ const debug = createDebug('database');
 // eslint-disable-next-line no-console
 export const logger = env.isProd() ? console.log : debug;
 
-export { default as sequelize } from './sequelize';
+export * as sequelize from './sequelize';
 export { default as umzug } from './umzug';

--- a/src/database/config/sequelize.ts
+++ b/src/database/config/sequelize.ts
@@ -1,4 +1,4 @@
-import { Sequelize } from 'sequelize';
+import { Options, Sequelize } from 'sequelize';
 import { env } from '@/config';
 import { isDebugger } from '@/database/types';
 
@@ -17,8 +17,19 @@ export const getInstance = (logger: (message: string) => void): Sequelize => {
       ? logger.extend('sequelize')(`%s ${timing ? '~ %d ms' : ''}`, sql, timing)
       : logger(`${sql} ~ ${timing}ms`);
 
-  return new Sequelize(dbUri, {
+  const options: Options = {
     benchmark: env.isDev(),
     logging,
-  });
+  };
+
+  if (env.isProd()) {
+    options.dialectOptions = {
+      ssl: {
+        require: true,
+        rejectUnauthorized: false, // Для устранения ошибки SequelizeConnectionError: self signed certificate
+      },
+    };
+  }
+
+  return new Sequelize(dbUri, options);
 };

--- a/src/database/config/sequelize.ts
+++ b/src/database/config/sequelize.ts
@@ -1,45 +1,21 @@
-import type { Options } from 'sequelize';
-
+import { Sequelize } from 'sequelize';
 import { env } from '@/config';
-import { normalizePort } from '@/server/utils';
 import { isDebugger } from '@/database/types';
 
-const DIALECT = 'postgres';
+const dbUri =
+  process.env.DATABASE_URL ??
+  'postgres://postgres:example@localhost:5432/galaga';
 
-const BASE_CONFIG: Options = {
-  username: process.env.POSTGRES_USER,
-  password: process.env.POSTGRES_PASSWORD,
-  database: process.env.POSTGRES_DB,
-  host: process.env.DB_HOST,
-  port: normalizePort(process.env.DB_PORT || '5432'),
-  dialect: DIALECT,
+// postgres://<userName>:<userPassword>@<host>:<port>/<databaseName>
 
-  benchmark: env.isDev(),
-};
-
-const getConfig = (logger: (message: string) => void): Options => {
+export const getInstance = (logger: (message: string) => void): Sequelize => {
   const logging = (sql: string, timing?: number) =>
     isDebugger(logger)
       ? logger.extend('sequelize')(`%s ${timing ? '~ %d ms' : ''}`, sql, timing)
       : logger(`${sql} ~ ${timing}ms`);
-  switch (env.contextName) {
-    case 'test':
-      return {
-        ...BASE_CONFIG,
-        database: `${BASE_CONFIG.database}_test`,
-        logging,
-      };
-    case 'production':
-      return { ...BASE_CONFIG, logging };
-    default:
-      return {
-        ...BASE_CONFIG,
-        database: `${BASE_CONFIG.database}_dev`,
-        logging,
-      };
-  }
-};
 
-export default {
-  getConfig,
+  return new Sequelize(dbUri, {
+    benchmark: env.isDev(),
+    logging,
+  });
 };

--- a/src/database/config/sequelize.ts
+++ b/src/database/config/sequelize.ts
@@ -2,9 +2,12 @@ import { Sequelize } from 'sequelize';
 import { env } from '@/config';
 import { isDebugger } from '@/database/types';
 
+const { POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB, DB_HOST, DB_PORT } =
+  process.env;
+
 const dbUri =
   process.env.DATABASE_URL ??
-  'postgres://postgres:example@localhost:5432/galaga';
+  `postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DB_HOST}:${DB_PORT}/${POSTGRES_DB}`;
 
 // postgres://<userName>:<userPassword>@<host>:<port>/<databaseName>
 

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,10 +1,9 @@
-import { Sequelize } from 'sequelize';
 import { Umzug } from 'umzug';
 import { waitDB } from '@/database/utils';
 import { logger, sequelize, umzug } from '@/database/config';
 import { TInitializationFn } from './types';
 
-const sequelizeInstance = new Sequelize(sequelize.getConfig(logger));
+const sequelizeInstance = sequelize.getInstance(logger);
 const migrationsManager = new Umzug(umzug.getConfig(sequelizeInstance, logger));
 
 export const initializeDB: TInitializationFn = async ({ models }) => {

--- a/src/database/utils/waitDb.ts
+++ b/src/database/utils/waitDb.ts
@@ -14,10 +14,11 @@ const waitDB = async (
   logger = defaultLogger
 ): Promise<Error | null> => {
   logger(
-    `waiting connection [${sequelize.config.username}@${sequelize.config.host}:${sequelize.config.port}?db=${sequelize.config.database}] ....`
+    `waiting connection [postgres://${sequelize.config.username}@${sequelize.config.host}:${sequelize.config.port}/${sequelize.config.database}] ....`
   );
   try {
     await sequelize.authenticate();
+    logger('connection success');
     return null;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {

--- a/src/server/middlewares/render/render.ts
+++ b/src/server/middlewares/render/render.ts
@@ -10,6 +10,8 @@ const renderMiddleware: RequestHandler = async (req, res) => {
   let starsTheme;
   let darkMode = true;
   let current;
+  let profile = null;
+
   const starsThemeFromDb = await dbThemeController.getThemeByName('Stars');
   if (!starsThemeFromDb) {
     starsTheme = {
@@ -36,10 +38,11 @@ const renderMiddleware: RequestHandler = async (req, res) => {
     const userTheme = await dbThemeController.getThemeByUser(user.id);
     darkMode = userTheme?.darkMode ?? true;
     current = userTheme?.current ?? starsTheme;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { yandexId, ...userProfile } = user;
+    profile = userProfile;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { yandexId, ...profile } = user;
   const initialState: TRootState = {
     user: { profile },
     themes: {


### PR DESCRIPTION
Поправлена инициализация базы данных для деплоя на heroku.

Наткнулся на [статью](https://www.howtographql.com/typescript-apollo/9-deployment/) где описано как поднять GraphQL на heroku и там описано что можно поднять бесплатный инстанс postgres. Собственно на ветке deploy протестировал все работает. Теперь приложение будет подниматься правильно. И heroku можно оставить как staging для тестов.

Также можно подробнее почитать по postgres на heroku [тут](https://www.heroku.com/postgres)

Поменяно создание инстанса sequelize, для совместимости оставил старые переменные env. Но теперь наше приложение реагирует на переменную `DATABASE_URL` в которую можно передать строку подключения к базе (старый способ задания конфигурации будет проигнорирован). Также добавил в конфигурацию sequelize использование SSL в prod режиме